### PR TITLE
Bugfix: GameLib.GetAccountRealmCharacter returns nil [#5]

### DIFF
--- a/GeminiDB-1.0.lua
+++ b/GeminiDB-1.0.lua
@@ -282,7 +282,7 @@ local preserve_keys = {
 }
 
 local realmKey = GameLib.GetRealmName()
-local charKey = GameLib.GetAccountRealmCharacter().strCharacter .. " - " .. realmKey
+local charKey = (GameLib.GetAccountRealmCharacter and GameLib.GetAccountRealmCharacter().strCharacter or GameLib.GetPlayerUnit():GetName()) .. " - " .. realmKey
 local localeKey = GetLocale():lower()
 
 local function populateKeys(self)


### PR DESCRIPTION
This bug was introduced by the last Gamelib hotfix (vers.12403), see #5 .