### PR TITLE
bumping version

### DIFF
--- a/GeminiDB-1.0.lua
+++ b/GeminiDB-1.0.lua
@@ -282,7 +282,7 @@ local preserve_keys = {
 }
 
 local realmKey = GameLib.GetRealmName()
-local charKey = (GameLib.GetAccountRealmCharacter and GameLib.GetAccountRealmCharacter().strCharacter or GameLib.GetPlayerUnit():GetName()) .. " - " .. realmKey
+local charKey = ((GameLib.GetAccountRealmCharacter and GameLib.GetAccountRealmCharacter().strCharacter) or GameLib.GetPlayerUnit():GetName()) .. " - " .. realmKey
 local localeKey = GetLocale():lower()
 
 local function populateKeys(self)

--- a/GeminiDB-1.0.lua
+++ b/GeminiDB-1.0.lua
@@ -32,7 +32,7 @@
 -- end
 -- @class file
 -- @name GeminiDB-1.0.lua
-local MAJOR, MINOR = "Gemini:DB-1.0", 6
+local MAJOR, MINOR = "Gemini:DB-1.0", 7
 local APkg = Apollo.GetPackage(MAJOR)
 if APkg and (APkg.nVersion or 0) >= MINOR then
 	return -- no upgrade is needed


### PR DESCRIPTION
## Description ##
With the changes done by Carbine, functionality has been removed from the API in WildStar.
The code has already been merged into master, but can we bump the version to 7 please to allow people who use this file somewhere to have a backup that the fix is loaded for all Addons?

That way  people just need to have one updated version to fix all their Addons again.

Related to #5 and #6