### PR TITLE
Replace deprecated GetAccountRealmCharacter

### DIFF
--- a/GeminiDB-1.0.lua
+++ b/GeminiDB-1.0.lua
@@ -282,7 +282,7 @@ local preserve_keys = {
 }
 
 local realmKey = GameLib.GetRealmName()
-local charKey = ((GameLib.GetAccountRealmCharacter and GameLib.GetAccountRealmCharacter().strCharacter) or GameLib.GetPlayerUnit():GetName()) .. " - " .. realmKey
+local charKey = GameLib.GetPlayerCharacterName() .. " - " .. realmKey
 local localeKey = GetLocale():lower()
 
 local function populateKeys(self)


### PR DESCRIPTION
Since the newest patch (ver.12501) GameLib.GetAccountRealmCharacter is now officially deprecated and will display a warning message to the user with the replacement functions:

`GetAccountRealmName is deprecated and will be removed in the near future. GameLib.GetPlayerCharacterName() and GameLib.GetRealmName() should be used instead.`

This is the proper fix to the workaround related to #5